### PR TITLE
Get the CI build running and passing 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,23 @@ jobs:
   build:
     docker:
       - image: circleci/ruby:2.5.3
+    working_directory: ~/infrastructure_adrs
     steps:
       - checkout
-      - run: rake
+      - run:
+          name: Configure bundler
+          command: |
+            echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
+            source $BASH_ENV
+            gem install bundler
+      - run:
+          name: Install dependencies
+          command: bundle install
+      - run:
+          name: Run CI
+          command: bundle exec rake
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build

--- a/.mdl.style.rb
+++ b/.mdl.style.rb
@@ -1,0 +1,4 @@
+# Start with all rules
+all
+# Don't care about line length
+exclude_rule "MD013"

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,4 +1,4 @@
+# Use our custom style ruleset
+style '.mdl.style.rb'
 # Jekyll requires front matter but mdl doesn't like it
 ignore_front_matter true
-# Don't care about line length
-rules "~MD013"

--- a/0000-use-madr-as-record-format.md
+++ b/0000-use-madr-as-record-format.md
@@ -4,7 +4,6 @@ title: ADR-0000
 nav_order: 3
 permalink: records/0000/
 ---
-
 # Use Markdown Architecture Decision Records
 
 * Status: proposed

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'mdl'
+gem 'rake'
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
+    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -253,6 +254,7 @@ DEPENDENCIES
   github-pages
   jekyll-feed (~> 0.6)
   mdl
+  rake
 
 BUNDLED WITH
    2.0.1

--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@ title: Home
 nav_order: 1
 permalink: /
 ---
-
 # Architecture Decision Records of the DLSS Infrastructure Team
-
-[![CircleCI](https://circleci.com/gh/sul-dlss-labs/infrastructure-adrs.svg?style=svg)](https://circleci.com/gh/sul-dlss-labs/infrastructure-adrs)
 
 This repository contains a running and evolving list of architecture decision records (ADRs), documenting architectural decisions made by the [DLSS Infrastructure Team](https://github.com/orgs/sul-dlss/teams/infrastructure-team). Architecture decisions pertain to practices, projects, policies, software, system architecture, and technology selection.
 

--- a/template.md
+++ b/template.md
@@ -4,7 +4,6 @@ title: Template
 nav_order: 2
 permalink: template/
 ---
-
 # [short title of solved problem and solution]
 
 * Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- required -->


### PR DESCRIPTION
Includes:

* Use `mdl` gem to lint/validate markdown files to prevent breaking the site
* Configure `mdl` to allow YAML front-matter (which we need for Jekyll) and ignore line length
* Execute default rake task (using bundler 2.0) in CI
  * Add rake dependency explicitly
* Remove CircleCI badge from README (because not useful and distracting when it renders in the site)