### PR TITLE
Mark 0000 as having been decided

### DIFF
--- a/0000-use-madr-as-record-format.md
+++ b/0000-use-madr-as-record-format.md
@@ -6,12 +6,20 @@ permalink: records/0000/
 ---
 # Use Markdown Architecture Decision Records
 
-* Status: proposed
+* Status: decided
 * Decider(s):
-  * Mike Giarlo
-  * *your name here*
+  * Infrastructure Team
+    * Justin Coyne
+    * Mike Giarlo
+    * Peter Mangiafico
+    * Jeremy Nelson
+    * Justin Littman
+    * Naomi Dushay
+    * John Martin
+    * Aaron Collier
 * Date(s):
   * Proposed: 2019-04-04
+  * Decided: 2020-01-28
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
Since the team has been using MADRs since last year, it seems we at least have *de facto* agreed on this format for architecture decision records. I am updating this ADR to reflect that we have decided as a group to move forward with this format.